### PR TITLE
FIX 修复无法搜索到少数歌曲的问题

### DIFF
--- a/flaskSystem/src/Common/Tools.py
+++ b/flaskSystem/src/Common/Tools.py
@@ -510,7 +510,11 @@ def fulfillMusicMetaData(musicFile, metaDataInfo):
             # 唱片公司
             label = meta['albumCollection']['company']['name']
             # GENRE 流派
-            gener = [it['name'] for it in meta['albumCollection']['basicInfo']['genres']]
+            # genres 可能为 None
+            gener = meta.get('albumCollection', {}).get('basicInfo', {}).get('genres')
+            if gener is not None:
+                for it in gener:
+                    gener.append(it['name'])
             # 专辑艺术家
             albumartist = [it['name'] for it in meta['albumCollection']['singer']['singerList']]
 
@@ -741,7 +745,7 @@ def write_metadata_information(
 
         music["TIT2"] = TIT2(encoding=3, text=title)
 
-        # 提取时间戳和歌词  
+        # 提取时间戳和歌词
         if lyric: music.setall("USLT", [USLT(encoding=Encoding.UTF8, lang='chi', format=2, type=1, text=lyric)])
 
         # 写入流派


### PR DESCRIPTION
由于 api 请求的 JSON 结果和 dict 搜索的**字段**不相符('genres' != 'genre'), 导致由于写入 meta 失败从而下载音乐失败

![image](https://github.com/QiuChenlyOpenSource/QQFlacMusicDownloader/assets/70408571/5c953398-0118-419b-a8d8-7bfd3687180a)
