### PR TITLE
FIX UnicodeEncodeError

### DIFF
--- a/flaskSystem/src/Common/Tools.py
+++ b/flaskSystem/src/Common/Tools.py
@@ -265,7 +265,7 @@ def downSingle(music, download_home, config):
 
             # 单独下载lrc歌词文件
             if saveLyric == True:
-                with open(localLrcFile, 'w') as f:
+                with open(localLrcFile, 'w', encoding='utf-8') as f:
                     f.write(lyric)
         else:
             print(f"歌词获取失败!服务器上搜索不到此首 [{music['singer']} - {music['title']}] 歌曲歌词!")


### PR DESCRIPTION
因为下歌词有时候会
```
  File "c:\Users\ideaexplorer233\Downloads\QQFlacMusicDownloader-main\flaskSystem\src\Common\Tools.py", line 269, in downSingle
    f.write(lyric)
UnicodeEncodeError: 'gbk' codec can't encode character '\xd8' in position 155: illegal multibyte sequence
```
所以强制一下它utf-8