### PR TITLE
修复酷我搜索接口从第二页开始搜索的小问题

### DIFF
--- a/flaskSystem/src/Api/Kuwo.py
+++ b/flaskSystem/src/Api/Kuwo.py
@@ -74,7 +74,7 @@ class KwApi(BaseApi):
               'openudid=&' \
               'uuid=&prod=kwplayer_mc_1.7.0&corp=kuwo&source=kwplayer_mc_1.7.0&' \
               'uid=&ver=kwplayer_mc_1.7.0&loginid=0&client=kt&cluster=0&strategy=2012&ver=mbox&' \
-              f'show_copyright_off=1&encoding=utf8&rformat=json&mobi=1&vipver=1&pn={page_num}&rn={page_size}&' \
+              f'show_copyright_off=1&encoding=utf8&rformat=json&mobi=1&vipver=1&pn={page_num-1}&rn={page_size}&' \
               f'all={searchKey}&ft=music'
         res = self.getUrl(url)
         res = res.json()


### PR DESCRIPTION
在使用酷我接口搜索时发现资源不全，原因在于他的起始页是从零开始的。